### PR TITLE
Correct capitalization of GitHub

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -11,7 +11,7 @@
     {
       "fullName": "Chris Wanstrath",
       "handle": "defunkt",
-      "bio": "CEO, Github",
+      "bio": "CEO, GitHub",
       "avatar": "defunkt.jpeg",
       "story": "Before cofounding GitHub I applied for an engineering job at Yahoo and didn’t get it. Don’t let other people discourage you.",
       "double": true


### PR DESCRIPTION
Github -> GitHub in Chris Wanstrath's bio.